### PR TITLE
OM-27: Fix SDK Generation

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -31,7 +31,7 @@ jobs:
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
           echo "${{ secrets.FH_OPS_SSH_KEY }}" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
+          chmod 400 ~/.ssh/id_ed25519
           ssh-agent -a $SSH_AUTH_SOCK > /dev/null
           ssh-add ~/.ssh/id_ed25519
           

--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           repository: firehydrant/developers
           path: 'dev-repo'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CROSS_REPO_TOKEN }}
           
       - name: Copy OpenAPI spec
         run: |
@@ -44,6 +44,6 @@ jobs:
       mode: pr
       set_version: ${{ github.event.inputs.set_version }}
     secrets:
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      github_access_token: ${{ secrets.CROSS_REPO_TOKEN }}
       npm_token: ${{ secrets.NPM_TOKEN }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -18,12 +18,37 @@ permissions:
   schedule:
     - cron: 0 0 * * *
 jobs:
+  fetch_openapi:
+    runs-on: ubuntu-latest
+    outputs:
+      openapi_path: ${{ steps.save_openapi.outputs.openapi_path }}
+    steps:
+      - name: Checkout SDK repo
+        uses: actions/checkout@v3
+        
+      - name: Checkout developers repo
+        uses: actions/checkout@v3
+        with:
+          repository: firehydrant/developers
+          path: 'dev-repo'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Copy OpenAPI spec
+        run: |
+          mkdir -p .speakeasy
+          cp dev-repo/docs/public/openapi3_doc.json .speakeasy/openapi.json
+          
+      - id: save_openapi
+        run: echo "openapi_path=.speakeasy/openapi.json" >> $GITHUB_OUTPUT
+
   generate:
+    needs: fetch_openapi
     uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
     with:
       force: ${{ github.event.inputs.force }}
       mode: pr
       set_version: ${{ github.event.inputs.set_version }}
+      openapi_path: ${{ needs.fetch_openapi.outputs.openapi_path }}
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -20,8 +20,6 @@ permissions:
 jobs:
   fetch_openapi:
     runs-on: ubuntu-latest
-    outputs:
-      openapi_path: ${{ steps.save_openapi.outputs.openapi_path }}
     steps:
       - name: Checkout SDK repo
         uses: actions/checkout@v3
@@ -37,9 +35,6 @@ jobs:
         run: |
           mkdir -p .speakeasy
           cp dev-repo/docs/public/openapi3_doc.json .speakeasy/openapi.json
-          
-      - id: save_openapi
-        run: echo "openapi_path=.speakeasy/openapi.json" >> $GITHUB_OUTPUT
 
   generate:
     needs: fetch_openapi
@@ -48,7 +43,6 @@ jobs:
       force: ${{ github.event.inputs.force }}
       mode: pr
       set_version: ${{ github.event.inputs.set_version }}
-      openapi_path: ${{ needs.fetch_openapi.outputs.openapi_path }}
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -54,6 +54,6 @@ jobs:
           force: ${{ github.event.inputs.force }}
           mode: pr
           set_version: ${{ github.event.inputs.set_version }}
-          github_access_token: ${{ secrets.CROSS_REPO_TOKEN }}
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
           npm_token: ${{ secrets.NPM_TOKEN }}
           SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -21,7 +21,7 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout developers repo
+      - name: Clone SDK repo
         uses: actions/checkout@v3
         
       - name: Set up SSH
@@ -39,14 +39,14 @@ jobs:
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         run: |
-          git clone git@github.com:firehydrant/developers.git dev-repo
-          cd dev-repo
+          git clone git@github.com:firehydrant/developers.git /tmp/dev-repo
+          cd /tmp/dev-repo
           git checkout main
           
       - name: Copy OpenAPI spec
         run: |
           mkdir -p .speakeasy
-          cp dev-repo/docs/public/openapi3_doc.json ${GITHUB_WORKSPACE}/openapi.json
+          cp /tmp/dev-repo/docs/public/openapi3_doc.json ${GITHUB_WORKSPACE}/openapi.json
           
       - name: Generate SDK
         uses: speakeasy-api/sdk-generation-action@v15

--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -18,32 +18,42 @@ permissions:
   schedule:
     - cron: 0 0 * * *
 jobs:
-  fetch_openapi:
+  generate:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout SDK repo
-        uses: actions/checkout@v3
-        
       - name: Checkout developers repo
         uses: actions/checkout@v3
-        with:
-          repository: firehydrant/developers
-          path: 'dev-repo'
-          token: ${{ secrets.CROSS_REPO_TOKEN }}
+        
+      - name: Set up SSH
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          echo "${{ secrets.FH_OPS_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-add ~/.ssh/id_ed25519
+          
+      - name: Clone developers repo
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        run: |
+          git clone git@github.com:firehydrant/developers.git dev-repo
+          cd dev-repo
+          git checkout main
           
       - name: Copy OpenAPI spec
         run: |
           mkdir -p .speakeasy
-          cp dev-repo/docs/public/openapi3_doc.json .speakeasy/openapi.json
-
-  generate:
-    needs: fetch_openapi
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
-    with:
-      force: ${{ github.event.inputs.force }}
-      mode: pr
-      set_version: ${{ github.event.inputs.set_version }}
-    secrets:
-      github_access_token: ${{ secrets.CROSS_REPO_TOKEN }}
-      npm_token: ${{ secrets.NPM_TOKEN }}
-      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+          cp dev-repo/docs/public/openapi3_doc.json ${GITHUB_WORKSPACE}/openapi.json
+          
+      - name: Generate SDK
+        uses: speakeasy-api/sdk-generation-action@v15
+        with:
+          force: ${{ github.event.inputs.force }}
+          mode: pr
+          set_version: ${{ github.event.inputs.set_version }}
+          github_access_token: ${{ secrets.CROSS_REPO_TOKEN }}
+          npm_token: ${{ secrets.NPM_TOKEN }}
+          SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -3,7 +3,7 @@ speakeasyVersion: latest
 sources:
     firehydrant-oas:
         inputs:
-            - location: https://raw.githubusercontent.com/firehydrant/developers/main/docs/public/openapi3_doc.json
+            - location: ./.speakeasy/openapi.json
         registry:
             location: registry.speakeasyapi.dev/firehydrant/firehydrant/firehydrant-oas
 targets:

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -3,10 +3,7 @@ speakeasyVersion: latest
 sources:
     firehydrant-oas:
         inputs:
-            - location: ./openapi.yaml
-        overlays:
-            - location: .speakeasy/speakeasy-modifications-overlay.yaml
-            - location: errors-overlay.yaml
+            - location: https://raw.githubusercontent.com/firehydrant/developers/main/docs/public/openapi3_doc.json
         registry:
             location: registry.speakeasyapi.dev/firehydrant/firehydrant/firehydrant-oas
 targets:

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -3,7 +3,7 @@ speakeasyVersion: latest
 sources:
     firehydrant-oas:
         inputs:
-            - location: ./.speakeasy/openapi.json
+            - location: ${GITHUB_WORKSPACE}/openapi.json
         registry:
             location: registry.speakeasyapi.dev/firehydrant/firehydrant/firehydrant-oas
 targets:


### PR DESCRIPTION
https://firehydrant.atlassian.net/browse/OM-27

Updates the workflow to use the remote openapi spec from the developers repository, which is updated regularly. This change allows us to maintain a single source of truth for the OAS and prevents us from needing to update local spec in respective sdk repositories. 

This also removes overlays with the intention of using our Grape documentation as a source of truth and reducing manual mapping. The work done to add nicknames to all our endpoints in https://github.com/firehydrant/laddertruck/pull/13576 will help in this regard. 

There is further opportunity to improve the sync between readme changes and sdk changes. The developers repo checks for updates to the swagger docs every 30m and update the OAS accordingly. Crons in sdk repos currently run daily. Planning future work to trigger SDK workflow from the developers repo if/when the OAS is updated.