### PR TITLE
RD-17: Update SDK

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -3,32 +3,40 @@ generation:
   devContainers:
     enabled: true
     schemaPath: registry.speakeasyapi.dev/firehydrant/firehydrant/firehydrant-oas:main
-  sdkClassName: FirehydrantTypescriptSdk
+  sdkClassName: Firehydrant
   maintainOpenAPIOrder: true
   usageSnippets:
     optionalPropertyRendering: withExample
   useClassNamesForArrayFields: true
   fixes:
     nameResolutionDec2023: true
+    nameResolutionFeb2025: true
     parameterOrderingFeb2024: true
     requestResponseComponentNamesFeb2024: true
+    securityFeb2025: false
+    sharedErrorComponentsApr2025: false
   auth:
     oAuth2ClientCredentialsEnabled: true
     oAuth2PasswordEnabled: true
 typescript:
-  version: 0.0.11
+  version: 0.1.13
   additionalDependencies:
     dependencies: {}
     devDependencies: {}
     peerDependencies: {}
   additionalPackageJSON: {}
-  author: Speakeasy
+  author: Firehydrant
   clientServerStatusCodesAsErrors: true
   defaultErrorName: APIError
+  enableCustomCodeRegions: false
+  enableMCPServer: true
   enableReactQuery: false
   enumFormat: union
-  envVarPrefix: FIREHYDRANTTYPESCRIPTSDK
+  envVarPrefix: FIREHYDRANT
   flattenGlobalSecurity: true
+  flattenSdk: true
+  flattenSpecOptions:
+    tags: false
   flatteningOrder: parameters-first
   imports:
     option: openapi
@@ -39,11 +47,12 @@ typescript:
       shared: models/components
       webhooks: models/webhooks
   inputModelSuffix: input
+  jsonpath: legacy
   maxMethodParams: 0
   methodArguments: require-security-and-request
-  moduleFormat: commonjs
+  moduleFormat: dual
   outputModelSuffix: output
-  packageName: firehydrant-typescript-sdk
+  packageName: firehydrant
   responseFormat: flat
   templateVersion: v2
   useIndexModules: true


### PR DESCRIPTION
General readability improvements

Renames SDK to 'Firehydrant' from 'FirehydrantTypescriptSdk'
Sets Firehydrant as Author
Updates en var Prefix
Updates package name
Uses dual module

'Firehydrant' available on npm
<img width="1551" alt="Screenshot 2025-05-07 at 6 42 56 PM" src="https://github.com/user-attachments/assets/1175a407-6898-4a28-b517-a1f0be4aafff" />

<img width="636" alt="Screenshot 2025-05-07 at 9 00 52 PM" src="https://github.com/user-attachments/assets/c72ed3af-abc1-41d4-b676-26ed815aea52" />

<img width="1072" alt="Screenshot 2025-05-07 at 9 01 27 PM" src="https://github.com/user-attachments/assets/3d4ba54d-1b13-48b5-a8c8-61077ae262df" />
