### PR TITLE
Fix package-name

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -52,7 +52,7 @@ typescript:
   methodArguments: require-security-and-request
   moduleFormat: dual
   outputModelSuffix: output
-  packageName: firehydrant
+  packageName: firehydrant-typescript-sdk
   responseFormat: flat
   templateVersion: v2
   useIndexModules: true


### PR DESCRIPTION
Fixes an error seen while publishing to npm. Existing package fire-hydrant too similar, setting package name to firehydrant-typescript-sdk

<img width="1258" alt="Screenshot 2025-05-12 at 9 43 24 AM" src="https://github.com/user-attachments/assets/28202ae7-4bf2-4e3f-8ee4-756b96d37b6b" />
